### PR TITLE
chore(core): add AlaudaDevops/harbor-cli to fork versioning whitelist

### DIFF
--- a/core.json5
+++ b/core.json5
@@ -12,6 +12,7 @@
                 "AlaudaDevops/tektoncd-cli",
                 "AlaudaDevops/trivy",
                 "AlaudaDevops/harbor-scanner-trivy",
+                "AlaudaDevops/harbor-cli",
                 "AlaudaDevops/git-clone",
                 "AlaudaDevops/syft",
                 "AlaudaDevops/cosign",


### PR DESCRIPTION
## Summary

Add `AlaudaDevops/harbor-cli` to the github-releases packageRule whitelist in `core.json5`, so Renovate uses the `vX.Y.Z-alauda-N` versioning regex for harbor-cli fork releases — consistent with `harbor-scanner-trivy`, `trivy`, `tektoncd-cli`, etc.

## Context

harbor-cli just got Renovate onboarding at AlaudaDevops/harbor-cli#2 on the `alauda-v0.0.18` branch. Fork releases will follow the `vX.Y.Z-alauda-N` tag convention. Without this whitelist entry, downstream repos that depend on harbor-cli releases (via github-releases) would not know how to compare fork tags and might propose incorrect update PRs.

## Test plan

- [x] Diff is the single line addition between `harbor-scanner-trivy` and `git-clone`
- [ ] No downstream regression (rule only narrows behavior for this specific repo's github-releases lookups)

🤖 Generated with [Claude Code](https://claude.com/claude-code)